### PR TITLE
Populate the gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/.bundle/
+/.yardoc
+/Gemfile.lock
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,13 @@
+PreCommit:
+  RuboCop:
+    enabled: true
+    required: false
+    on_warn: fail
+
+  HardTabs:
+    enabled: true
+    required: false
+
+CommitMsg:
+  TrailingPeriod:
+    enabled: false

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,11 @@
+inherit_gem:
+  salsify_rubocop: conf/rubocop.yml
+
+Style/FileName:
+  Exclude:
+    - 'lib/avro-resolution_canonical_form.rb'
+
+RSpec/FilePath:
+  Enabled: false
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+  - 2.3.3
+before_install: gem install bundler -v 1.14.6
+script:
+  - bundle exec rubocop
+  - bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# avro-resolution_canonical_form
+
+## v0.1.0
+- Initial version

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,4 @@
-
 source 'https://rubygems.org'
-
 
 # override the :github shortcut to be secure by using HTTPS
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+
+source 'https://rubygems.org'
+
+
+# override the :github shortcut to be secure by using HTTPS
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
+
+# Specify your gem's dependencies in avro-resolution_canonical_form.gemspec
+gemspec

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Salsify, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,107 @@
 # avro-resolution_canonical_form
+
+This gem defines a [Resolution Canonical Form](#resolution_canonical_form) for Avro schemas.
+This is similar to the [Parsing Canonical Form](http://avro.apache.org/docs/1.8.1/spec.html#Parsing+Canonical+Form+for+Schemas)
+from the Apache Avro spec, but extends is to also include attributes that are
+relevant to schema resolution and compatibility.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'avro-resolution_canonical_form'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install avro-resolution_canonical_form
+
+## Resolution Canonical Form
+
+The Resolution Canonical Form extends the [Parsing Canonical Form](http://avro.apache.org/docs/1.8.1/spec.html#Parsing+Canonical+Form+for+Schemas)
+to include `default` and `aliases` attributes:
+
+* [ORDER] Order the appearance of fields in JSON objects as follows:
+  `name, type, fields, symbols, items, values, size, default, aliases`
+* [ALIASES] [Aliases](http://avro.apache.org/docs/1.8.1/spec.html#Aliases) for
+  named types and fields are converted to their fullname, using applicable
+  namespace, and sorted.
+
+## Ruby Support
+
+This currently gem requires the [avro-salsify-fork](https://github.com/salsify/avro)
+gem due to a bug in the Avro Ruby gem support for defaults. The fix for this issue
+will be included in Avro v1.8.2.
+
+### Aliases
+
+The Avro Ruby gem, including the avro-salsify-fork, does not yet include support
+for aliases. Aliases are included in the specification of the Resolution Canonical
+Form above, but not yet supported by this gem.
+
+## Usage
+
+`Avro::ResolutionCanonicalForm` subclasses `Avro::SchemaNormalization`
+and provides a `to_resolution_form` method that returns the resolution canonical
+form for the schema:
+
+```ruby
+require 'avro-resolution_canonical_form'
+
+schema = Avro::Schema.parse(<<-JSON)
+  {
+    "type": "record",
+    "name": "dimensions",
+    "aliases": ["dims", "eg.sizing"],
+    "namespace": "example",
+    "doc": "an example",
+    "fields": [
+      { "name": "height", "type": "int", "default": 1, "doc": "the height" },
+      { "name": "width", "aliases": ["across"], "type": "int", "doc": "the width" }
+    ]
+  }
+JSON
+
+Avro::ResolutionCanonicalForm.to_resolution_form(schema)
+#=> {"name":"example.dimensions","type":"record","fields":[{"name":"height","type":"int","default":1},{"name":"width","type":"int"}]}
+```
+
+A new method, `#sha256_resolution_fingerprint`, is added to `Avro::Schema` to
+return the SHA256 digest based on the resolution form above. This is similar to
+the existing `#sha256_fingerprint` which is based on the Parsing Canonical Form.
+
+```ruby
+schema.sha256_resolution_fingerprint
+
+#=> 80361294467930602613800428579400567035362599364974249578710466785512094641526
+```
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then,
+run `rake spec` to run the tests. You can also run `bin/console` for an
+interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. 
+
+To release a new version, update the version number in `version.rb`, and then
+run `bundle exec rake release`, which will create a git tag for the version,
+push git commits and tags, and push the `.gem` file to
+[rubygems.org](https://rubygems.org)
+.
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at
+https://github.com/salsify/avro-resolution_canonical_form.
+
+## License
+
+The gem is available as open source under the terms of the
+[MIT License](http://opensource.org/licenses/MIT).
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,8 @@
+require 'bundler/gem_tasks'
+
+
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/avro-resolution_canonical_form.gemspec
+++ b/avro-resolution_canonical_form.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   # Set 'allowed_push_post' to control where this gem can be published.
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = 'https://rubygems.org'
-
   else
     raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
   end

--- a/avro-resolution_canonical_form.gemspec
+++ b/avro-resolution_canonical_form.gemspec
@@ -1,0 +1,38 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'avro/resolution_canonical_form/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'avro-resolution_canonical_form'
+  spec.version       = Avro::ResolutionCanonicalForm::VERSION
+  spec.authors       = ['Salsify, Inc']
+  spec.email         = ['engineering@salsify.com']
+
+  spec.summary       = 'Unique identification of Avro schemas for schema resolution'
+  spec.description   = spec.summary
+  spec.homepage      = 'https://github.com/salsify/avro-resolution_canonical_form'
+
+  spec.license       = 'MIT'
+
+  # Set 'allowed_push_post' to control where this gem can be published.
+  if spec.respond_to?(:metadata)
+    spec.metadata['allowed_push_host'] = 'https://rubygems.org'
+
+  else
+    raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
+  end
+
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.bindir        = 'bin'
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.require_paths = ['lib']
+
+  spec.add_development_dependency 'bundler', '~> 1.12'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.4'
+  spec.add_development_dependency 'salsify_rubocop', '~> 0.46.0'
+  spec.add_development_dependency 'overcommit'
+  spec.add_development_dependency 'simplecov'
+  spec.add_runtime_dependency 'avro-salsify-fork', '>= 1.9.0.5'
+end

--- a/avro-resolution_canonical_form.gemspec
+++ b/avro-resolution_canonical_form.gemspec
@@ -1,11 +1,11 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'avro/resolution_canonical_form/version'
+require 'avro-resolution_canonical_form/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'avro-resolution_canonical_form'
-  spec.version       = Avro::ResolutionCanonicalForm::VERSION
+  spec.version       = AvroResolutionCanonicalForm::VERSION
   spec.authors       = ['Salsify, Inc']
   spec.email         = ['engineering@salsify.com']
 

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'avro-resolution_canonical_form'
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require 'irb'
+IRB.start

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -v
+
+bundle update
+
+overcommit --install

--- a/lib/avro-resolution_canonical_form.rb
+++ b/lib/avro-resolution_canonical_form.rb
@@ -1,3 +1,3 @@
-require 'avro/resolution_canonical_form/version'
+require 'avro-resolution_canonical_form/version'
 require 'avro/resolution_canonical_form'
 require 'avro/resolution_fingerprint'

--- a/lib/avro-resolution_canonical_form.rb
+++ b/lib/avro-resolution_canonical_form.rb
@@ -1,0 +1,3 @@
+require 'avro/resolution_canonical_form/version'
+require 'avro/resolution_canonical_form'
+require 'avro/resolution_fingerprint'

--- a/lib/avro-resolution_canonical_form/version.rb
+++ b/lib/avro-resolution_canonical_form/version.rb
@@ -1,0 +1,3 @@
+module AvroResolutionCanonicalForm
+  VERSION = '0.1.0.rc1'.freeze
+end

--- a/lib/avro/resolution_canonical_form.rb
+++ b/lib/avro/resolution_canonical_form.rb
@@ -1,0 +1,31 @@
+require 'avro'
+
+module Avro
+  class ResolutionCanonicalForm < SchemaNormalization
+    def self.to_resolution_form(schema)
+      new.to_resolution_form(schema)
+    end
+
+    def to_resolution_form(schema)
+      MultiJson.dump(normalize_schema(schema))
+    end
+
+    private
+
+    # TODO: include aliases once the avro Ruby gem supports them
+    # Note: permitted values for defaults are not enforced here.
+    # That should be done at the schema level, and is not done currently
+    # in the Avro Ruby gem
+    def normalize_field(field)
+      default_value = if field.default?
+                        { default: field.default }
+                      else
+                        {}
+                      end
+      super.merge(default_value)
+    end
+
+    # TODO: Override normalize_named_type once the Avro Ruby gem supports aliases
+    # def normalized_named_type(schema, attributes = {})
+  end
+end

--- a/lib/avro/resolution_canonical_form/version.rb
+++ b/lib/avro/resolution_canonical_form/version.rb
@@ -1,7 +1,0 @@
-require 'avro'
-
-module Avro
-  class ResolutionCanonicalForm < SchemaNormalization
-    VERSION = '0.1.0.rc0'.freeze
-  end
-end

--- a/lib/avro/resolution_canonical_form/version.rb
+++ b/lib/avro/resolution_canonical_form/version.rb
@@ -1,0 +1,7 @@
+require 'avro'
+
+module Avro
+  class ResolutionCanonicalForm < SchemaNormalization
+    VERSION = '0.1.0.rc0'.freeze
+  end
+end

--- a/lib/avro/resolution_fingerprint.rb
+++ b/lib/avro/resolution_fingerprint.rb
@@ -1,0 +1,10 @@
+module Avro
+  class Schema
+    # Returns the SHA-256 fingerprint of the Resolution Canonical Form for the
+    # schema as an Integer
+    def sha256_resolution_fingerprint
+      resolution_form = ResolutionCanonicalForm.to_resolution_form(self)
+      Digest::SHA256.hexdigest(resolution_form).to_i(16)
+    end
+  end
+end

--- a/spec/avro/resolution_canonical_form_spec.rb
+++ b/spec/avro/resolution_canonical_form_spec.rb
@@ -1,0 +1,166 @@
+describe Avro::ResolutionCanonicalForm do
+  let(:resolution_form) { described_class.to_resolution_form(schema) }
+
+  describe "self.to_resolution_form" do
+    context "primitive types" do
+      %w(null boolean string bytes int long float double).each do |type|
+        it "returns the resolution canonical form for '#{type}'" do
+          schema = Avro::Schema.parse(<<-JSON)
+            { "type": "#{type}" }
+          JSON
+          expect(described_class.to_resolution_form(schema)).to eq(%("#{type}"))
+        end
+      end
+    end
+
+    shared_examples_for "resolution normalization" do
+      it "returns the resolution canonical form" do
+        expect(resolution_form).to eq(expected_type)
+      end
+    end
+
+    context "a record" do
+      let(:schema) do
+        Avro::Schema.parse(<<-JSON)
+          {
+            "type": "record",
+            "name": "test",
+            "namespace": "random",
+            "doc": "some record",
+            "fields": [
+              { "name": "height", "type": "int", "default": 1, "doc": "the height" },
+              { "name": "width", "type": "int", "doc": "the width" }
+            ]
+          }
+        JSON
+      end
+      let(:expected_type) do
+        <<-JSON.strip
+          {"name":"random.test","type":"record","fields":[{"name":"height","type":"int","default":1},{"name":"width","type":"int"}]}
+        JSON
+      end
+
+      it_behaves_like "resolution normalization"
+    end
+
+    context "a record with a field with an alias" do
+      let(:schema) do
+        Avro::Schema.parse(<<-JSON)
+          {
+            "type": "record",
+            "name": "test",
+            "namespace": "random",
+            "doc": "some record",
+            "fields": [
+              {
+                "name": "height",
+                "type": "int",
+                "aliases": ["vertical", "how.tall"],
+                "default": 1,
+                "doc": "the height" }
+            ]
+          }
+        JSON
+      end
+      let(:expected_type) do
+        # This is expected to change if alias support is added
+        <<-JSON.strip
+          {"name":"random.test","type":"record","fields":[{"name":"height","type":"int","default":1}]}
+        JSON
+      end
+
+      it_behaves_like "resolution normalization"
+    end
+
+    context "recursive records" do
+      let(:schema) do
+        Avro::Schema.parse(<<-JSON)
+          {
+            "type": "record",
+            "name": "item",
+            "fields": [
+              { "name": "next", "type": "item" }
+            ]
+          }
+        JSON
+      end
+      let(:expected_type) do
+        <<-JSON.strip
+          {"name":"item","type":"record","fields":[{"name":"next","type":"item"}]}
+        JSON
+      end
+
+      it_behaves_like "resolution normalization"
+    end
+
+    context "a record with an alias" do
+      let(:schema) do
+        Avro::Schema.parse(<<-JSON)
+          {
+            "type": "record",
+            "name": "test",
+            "aliases": ["resolution.test", "example"],
+            "namespace": "random",
+            "doc": "some record",
+            "fields": [
+              { "name": "width", "type": "int", "doc": "the width" }
+            ]
+          }
+        JSON
+      end
+      let(:expected_type) do
+        # This is expected to change if alias support is added
+        <<-JSON.strip
+          {"name":"random.test","type":"record","fields":[{"name":"width","type":"int"}]}
+        JSON
+      end
+
+      it_behaves_like "resolution normalization"
+    end
+
+    context "an enum type" do
+      let(:schema) do
+        Avro::Schema.parse(<<-JSON)
+          {
+            "type": "enum",
+            "name": "suit",
+            "aliase": ["family"],
+            "namespace": "cards",
+            "doc": "the different suits of cards",
+            "symbols": ["club", "hearts", "diamond", "spades"]
+          }
+        JSON
+      end
+      let(:expected_type) do
+        # This is expected to change if alias support is added
+        <<-JSON.strip
+          {"name":"cards.suit","type":"enum","symbols":["club","hearts","diamond","spades"]}
+        JSON
+      end
+
+      it_behaves_like "resolution normalization"
+    end
+
+    context "a fixed type" do
+      let(:schema) do
+        Avro::Schema.parse(<<-JSON)
+          {
+            "type": "fixed",
+            "name": "id",
+            "aliases": ["identifier", "internal.id"],
+            "namespace": "db",
+            "size": 64
+          }
+        JSON
+      end
+      let(:expected_type) do
+        # This is expected to change if alias support is added
+        <<-JSON.strip
+          {"name":"db.id","type":"fixed","size":64}
+        JSON
+      end
+
+      it_behaves_like "resolution normalization"
+    end
+  end
+end

--- a/spec/avro/resolution_fingerprint_spec.rb
+++ b/spec/avro/resolution_fingerprint_spec.rb
@@ -1,0 +1,142 @@
+describe Avro::Schema, "#sha256_resolution_fingerprint" do
+  describe "#sha256_resolution_fingerprint" do
+    let(:fingerprint) { schema.sha256_resolution_fingerprint }
+
+    shared_examples_for "a fingerprint based on the resolution canonical form" do
+      it "returns the fingerprint" do
+        expect(fingerprint).to eq(expected)
+      end
+    end
+
+    context "a primitive" do
+      let(:schema) do
+        Avro::Schema.parse <<-SCHEMA
+          { "type": "int" }
+        SCHEMA
+      end
+      let(:expected) do
+        # No different from Parsing Canonical Form fingerprint
+        schema.sha256_fingerprint
+      end
+
+      it_behaves_like "a fingerprint based on the resolution canonical form"
+    end
+
+    context "a record" do
+      let(:schema) do
+        Avro::Schema.parse(<<-JSON)
+          {
+            "type": "record",
+            "name": "test",
+            "namespace": "random",
+            "doc": "some record",
+            "fields": [
+              { "name": "height", "type": "int", "default": 1, "doc": "the height" },
+              { "name": "width", "type": "int", "doc": "the width" }
+            ]
+          }
+        JSON
+      end
+      let(:expected) do
+        76215121346273769907599941410596079616301682207627952515775291450295463500031
+      end
+
+      it_behaves_like "a fingerprint based on the resolution canonical form"
+
+      it "differs from the parsing fingerprint" do
+        expect(schema.sha256_fingerprint).not_to eq(expected)
+      end
+    end
+
+
+    context "a record with a field with an alias" do
+      let(:schema) do
+        Avro::Schema.parse(<<-JSON)
+          {
+            "type": "record",
+            "name": "test",
+            "namespace": "random",
+            "doc": "some record",
+            "fields": [
+              {
+                "name": "height",
+                "type": "int",
+                "aliases": ["vertical", "how.tall"],
+                "doc": "the height" }
+            ]
+          }
+        JSON
+      end
+      let(:expected) do
+        # This is expected to change if alias support is added
+        schema.sha256_fingerprint
+      end
+
+      it_behaves_like "a fingerprint based on the resolution canonical form"
+    end
+
+    context "a record with an alias" do
+      let(:schema) do
+        Avro::Schema.parse(<<-JSON)
+          {
+            "type": "record",
+            "name": "test",
+            "aliases": ["resolution.test", "example"],
+            "namespace": "random",
+            "doc": "some record",
+            "fields": [
+              { "name": "width", "type": "int", "doc": "the width" }
+            ]
+          }
+        JSON
+      end
+      let(:expected) do
+        # This is expected to change if alias support is added
+        schema.sha256_fingerprint
+      end
+
+      it_behaves_like "a fingerprint based on the resolution canonical form"
+    end
+
+    context "an enum type" do
+      let(:schema) do
+        Avro::Schema.parse(<<-JSON)
+          {
+            "type": "enum",
+            "name": "suit",
+            "aliase": ["family"],
+            "namespace": "cards",
+            "doc": "the different suits of cards",
+            "symbols": ["club", "hearts", "diamond", "spades"]
+          }
+        JSON
+      end
+      let(:expected) do
+        # This is expected to change if alias support is added
+        schema.sha256_fingerprint
+      end
+
+      it_behaves_like "a fingerprint based on the resolution canonical form"
+    end
+
+    context "a fixed type" do
+      let(:schema) do
+        Avro::Schema.parse(<<-JSON)
+          {
+            "type": "fixed",
+            "name": "id",
+            "aliases": ["identifier", "internal.id"],
+            "namespace": "db",
+            "size": 64
+          }
+        JSON
+      end
+      let(:expected) do
+        # This is expected to change if alias support is added
+        schema.sha256_fingerprint
+      end
+
+      it_behaves_like "a fingerprint based on the resolution canonical form"
+    end
+  end
+end

--- a/spec/avro_resolution_canonical_form_spec.rb
+++ b/spec/avro_resolution_canonical_form_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe Avro::ResolutionCanonicalForm, 'VERSION' do
+  it "has a version number" do
+    expect(Avro::ResolutionCanonicalForm::VERSION).not_to be nil
+  end
+end

--- a/spec/avro_resolution_canonical_form_spec.rb
+++ b/spec/avro_resolution_canonical_form_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe Avro::ResolutionCanonicalForm, 'VERSION' do
+describe AvroResolutionCanonicalForm, 'VERSION' do
   it "has a version number" do
-    expect(Avro::ResolutionCanonicalForm::VERSION).not_to be nil
+    expect(AvroResolutionCanonicalForm::VERSION).not_to be nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,5 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'simplecov'
+SimpleCov.start
+
+require 'avro-resolution_canonical_form'


### PR DESCRIPTION
This PR defines a new gem that defines a Resolution Canonical Form, and a new fingerprint based on that form, for Avro schemas.

There is actually very little code as the implementation is a couple of small changes on top the Avro Ruby gem.

The logic is implemented in a separate gem so that it can be used by the avro-schema-registry and avromatic, without needing to pull avromatic into the avro-schema-registry.

The changes are not implemented in avro-salsify-fork or contributed back to the Apache Avro project as that process is expected to be longer and will require more discussion.

Prime: @jturkel 