### PR TITLE
Update for Avro 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
 before_install: gem install bundler -v 2.0.1 --no-document
 before_script:
   - bundle exec appraisal install --jobs=3

--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,3 @@
-appraise 'avro-patches-0.x' do
-  gem 'avro-patches', '< 1.0.0'
-end
-
 appraise 'avro-patches-1.x' do
   gem 'avro-patches', '>= 1.0.0'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # avro-resolution_canonical_form
 
+## v0.3.0 (unreleased)
+- Require Avro v1.10.
+- Include aliases, enum defaults, and decimal logical types in the resolution
+  canonical form. Schemas that use any of these parts of the Avro spec will
+  get a different fingerprint with this version.
+
 ## v0.2.1
 - Restrict to `avro-patches` versions < 2.0.0.
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ Or install it yourself as:
 
 ## Resolution Canonical Form
 
-The Resolution Canonical Form extends the [Parsing Canonical Form](http://avro.apache.org/docs/1.8.1/spec.html#Parsing+Canonical+Form+for+Schemas)
-to include `default` and `aliases` attributes:
+The Resolution Canonical Form extends the [Parsing Canonical Form](http://avro.apache.org/docs/1.10.0/spec.html#Parsing+Canonical+Form+for+Schemas)
+to include `default` and `aliases` attributes and logical type for decimals:
 
+* [STRIP] Keep only attributes that are relevant to resolution, which are:
+  `name, type, fields, symbols, items, values, size, default, aliases, logical_type(=decimal), precision, scale`
 * [ORDER] Order the appearance of fields in JSON objects as follows:
   `name, type, fields, symbols, items, values, size, default, aliases`
-* [ALIASES] [Aliases](http://avro.apache.org/docs/1.8.1/spec.html#Aliases) for
+* [ALIASES] [Aliases](http://avro.apache.org/docs/1.10.0/spec.html#Aliases) for
   named types and fields are converted to their fullname, using applicable
   namespace, and sorted.
 
@@ -67,7 +69,7 @@ schema = Avro::Schema.parse(<<-JSON)
 JSON
 
 Avro::ResolutionCanonicalForm.to_resolution_form(schema)
-#=> {"name":"example.dimensions","type":"record","fields":[{"name":"height","type":"int","default":1},{"name":"width","type":"int"}]}
+#=> => "{\"name\":\"example.dimensions\",\"type\":\"record\",\"fields\":[{\"name\":\"height\",\"type\":\"int\",\"default\":1},{\"name\":\"width\",\"type\":\"int\",\"aliases\":[\"across\"]}],\"aliases\":[\"eg.sizing\",\"example.dims\"]}"
 ```
 
 A new method, `#sha256_resolution_fingerprint`, is added to `Avro::Schema` to
@@ -77,7 +79,7 @@ the existing `#sha256_fingerprint` which is based on the Parsing Canonical Form.
 ```ruby
 schema.sha256_resolution_fingerprint
 
-#=> 80361294467930602613800428579400567035362599364974249578710466785512094641526
+#=> 71676413924523555041213790831440929350080614901361467355865523343334332562796
 ```
 
 ## Development

--- a/avro-resolution_canonical_form.gemspec
+++ b/avro-resolution_canonical_form.gemspec
@@ -35,5 +35,20 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'salsify_rubocop', '~> 0.46.0'
   spec.add_development_dependency 'overcommit'
   spec.add_development_dependency 'simplecov'
+
+  spec.add_runtime_dependency 'avro', "~> 1.10.0"
   spec.add_runtime_dependency 'avro-patches', '< 2.0.0'
+
+  spec.post_install_message = %{
+avro-resolution_canonical_form now requires Avro v1.10.
+
+New features in Avro Ruby v1.10 are now included in the canonical form:
+  - aliases
+  - enum defaults
+  - decimal logical types
+
+Schemas that use any of these features will get a different fingerprint with
+this version. For projects that only use Ruby, use of these features is unlikely
+as they were previously unsupported.
+}
 end

--- a/avro-resolution_canonical_form.gemspec
+++ b/avro-resolution_canonical_form.gemspec
@@ -36,10 +36,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'overcommit'
   spec.add_development_dependency 'simplecov'
 
-  spec.add_runtime_dependency 'avro', "~> 1.10.0"
+  spec.add_runtime_dependency 'avro', '~> 1.10.0'
   spec.add_runtime_dependency 'avro-patches', '< 2.0.0'
 
-  spec.post_install_message = %{
+  spec.post_install_message = %(
 avro-resolution_canonical_form now requires Avro v1.10.
 
 New features in Avro Ruby v1.10 are now included in the canonical form:
@@ -50,5 +50,5 @@ New features in Avro Ruby v1.10 are now included in the canonical form:
 Schemas that use any of these features will get a different fingerprint with
 this version. For projects that only use Ruby, use of these features is unlikely
 as they were previously unsupported.
-}
+)
 end

--- a/lib/avro-resolution_canonical_form/version.rb
+++ b/lib/avro-resolution_canonical_form/version.rb
@@ -1,3 +1,3 @@
 module AvroResolutionCanonicalForm
-  VERSION = '0.2.1'.freeze
+  VERSION = '0.3.0'.freeze
 end

--- a/lib/avro/resolution_canonical_form.rb
+++ b/lib/avro/resolution_canonical_form.rb
@@ -2,7 +2,7 @@ require 'avro-patches'
 
 module Avro
   class ResolutionCanonicalForm < SchemaNormalization
-    DECIMAL_LOGICAL_TYPE = "decimal".freeze
+    DECIMAL_LOGICAL_TYPE = 'decimal'.freeze
 
     def self.to_resolution_form(schema)
       new.to_resolution_form(schema)

--- a/lib/avro/resolution_canonical_form.rb
+++ b/lib/avro/resolution_canonical_form.rb
@@ -25,7 +25,7 @@ module Avro
     def normalize_field(field)
       extensions = {}
       extensions[:default] = field.default if field.default?
-      if field.respond_to?(:aliases) && field.aliases && !field.aliases.empty?
+      if field.aliases && !field.aliases.empty?
         extensions[:aliases] = field.aliases.sort
       end
 
@@ -33,7 +33,7 @@ module Avro
     end
 
     def add_logical_type(schema, serialized)
-      if schema.respond_to?(:logical_type) && schema.logical_type == DECIMAL_LOGICAL_TYPE
+      if schema.logical_type == DECIMAL_LOGICAL_TYPE
         extensions = { logicalType: DECIMAL_LOGICAL_TYPE }
         extensions[:precision] = schema.precision if schema.respond_to?(:precision) && schema.precision
         extensions[:scale] = schema.scale if schema.respond_to?(:scale) && schema.scale
@@ -49,10 +49,9 @@ module Avro
         # For enum defaults
         extensions[:default] = schema.default unless schema.default.nil?
       end
-      if schema.respond_to?(:fullname_aliases)
-        aliases = schema.fullname_aliases
-        extensions[:aliases] = aliases.sort unless aliases.empty?
-      end
+
+      aliases = schema.fullname_aliases
+      extensions[:aliases] = aliases.sort unless aliases.empty?
       extensions = add_logical_type(schema, extensions)
       super.merge(extensions)
     end

--- a/spec/avro/resolution_fingerprint_spec.rb
+++ b/spec/avro/resolution_fingerprint_spec.rb
@@ -8,6 +8,12 @@ describe Avro::Schema, "#sha256_resolution_fingerprint" do
       end
     end
 
+    shared_examples_for "a fingerprint that differs from parsing canonical form" do
+      it "returns the fingerprint" do
+        expect(fingerprint).not_to eq(schema.sha256_fingerprint)
+      end
+    end
+
     context "a primitive" do
       let(:schema) do
         Avro::Schema.parse <<-SCHEMA
@@ -15,11 +21,50 @@ describe Avro::Schema, "#sha256_resolution_fingerprint" do
         SCHEMA
       end
       let(:expected) do
-        # No different from Parsing Canonical Form fingerprint
+        # No difference from Parsing Canonical Form fingerprint
         schema.sha256_fingerprint
       end
 
       it_behaves_like "a fingerprint based on the resolution canonical form"
+    end
+
+    context "bytes with decimal logical type" do
+      let(:schema) do
+        Avro::Schema.parse(<<-JSON)
+          {
+            "type": "bytes",
+            "logicalType": "decimal",
+            "precision": 4,
+            "scale": 2
+          }
+        JSON
+      end
+
+      let(:expected) do
+        43426978718629271103217491481906353617743628111159770510613790541912847774184
+      end
+
+      it_behaves_like "a fingerprint based on the resolution canonical form"
+      it_behaves_like "a fingerprint that differs from parsing canonical form"
+    end
+
+    context "bytes with decimal logical type and only precision" do
+      let(:schema) do
+        Avro::Schema.parse(<<-JSON)
+          {
+            "type": "bytes",
+            "logicalType": "decimal",
+            "precision": 4
+          }
+        JSON
+      end
+
+      let(:expected) do
+        12802922089401264000746941315799739654898256907199367681849125434025528903374
+      end
+
+      it_behaves_like "a fingerprint based on the resolution canonical form"
+      it_behaves_like "a fingerprint that differs from parsing canonical form"
     end
 
     context "a record" do
@@ -68,8 +113,7 @@ describe Avro::Schema, "#sha256_resolution_fingerprint" do
         JSON
       end
       let(:expected) do
-        # This is expected to change if alias support is added
-        schema.sha256_fingerprint
+        41824580905639955713912383523901481096154542298417736906857707278253262501123
       end
 
       it_behaves_like "a fingerprint based on the resolution canonical form"
@@ -91,8 +135,7 @@ describe Avro::Schema, "#sha256_resolution_fingerprint" do
         JSON
       end
       let(:expected) do
-        # This is expected to change if alias support is added
-        schema.sha256_fingerprint
+        75464744640852001426996643166120064129197712472970600732646526647284533479704
       end
 
       it_behaves_like "a fingerprint based on the resolution canonical form"
@@ -104,7 +147,7 @@ describe Avro::Schema, "#sha256_resolution_fingerprint" do
           {
             "type": "enum",
             "name": "suit",
-            "aliase": ["family"],
+            "aliases": ["family"],
             "namespace": "cards",
             "doc": "the different suits of cards",
             "symbols": ["club", "hearts", "diamond", "spades"]
@@ -112,8 +155,28 @@ describe Avro::Schema, "#sha256_resolution_fingerprint" do
         JSON
       end
       let(:expected) do
-        # This is expected to change if alias support is added
-        schema.sha256_fingerprint
+        61020363212270409218377207099557595293985490295392385899935597230071562257837
+      end
+
+      it_behaves_like "a fingerprint based on the resolution canonical form"
+    end
+
+    context "an enum type with a default" do
+      let(:schema) do
+        Avro::Schema.parse(<<-JSON)
+          {
+            "type": "enum",
+            "name": "suit",
+            "aliases": ["family"],
+            "namespace": "cards",
+            "doc": "the different suits of cards",
+            "symbols": ["club", "hearts", "diamond", "spades"],
+            "default": "diamond"
+          }
+        JSON
+      end
+      let(:expected) do
+        63531828704047373383544513449830771947491531187791621354409622739327366772267
       end
 
       it_behaves_like "a fingerprint based on the resolution canonical form"
@@ -132,8 +195,31 @@ describe Avro::Schema, "#sha256_resolution_fingerprint" do
         JSON
       end
       let(:expected) do
-        # This is expected to change if alias support is added
-        schema.sha256_fingerprint
+        45487341757747564218800088807604506579998219041491597587640008023295720141043
+      end
+
+      it_behaves_like "a fingerprint based on the resolution canonical form"
+    end
+
+    context "fixed type with decimal logical type" do
+      let(:schema) do
+        Avro::Schema.parse(<<-JSON)
+          {
+            "type": "fixed",
+            "name": "my_decimal",
+            "aliases": ["precise", "number.logical"],
+            "namespace": "logical",
+            "size": 10,
+            "logicalType": "decimal",
+            "precision": 8,
+            "scale": 2
+          }
+        JSON
+      end
+
+      let(:expected) do
+        # This is expected to change to the decimal logical type is fully supported for fixed in Avro Ruby
+        109010719941921900671474271265982157895832083260603382288605526885391235302023
       end
 
       it_behaves_like "a fingerprint based on the resolution canonical form"


### PR DESCRIPTION
Ruby Avro v1.10 now supports some features that affect resolution: aliases, enum defaults, decimal logical types.

I debated maintaining compatibility with earlier versions, but this gem has changed very little. Instead I think it makes sense to  focus on just the current major Avro release.

As a result of these changes, some schemas could get a different fingerprint. But since these features were not previously supported by Ruby, it is unlikely that many schemas will be affected if only Ruby is used with Avro.

If the updated canonical form/fingerprint is used with a schema registry, then the impact may be that an additional version is registered for an existing schema but the change should not introduce any incompatibility between the versions.

If a schema was previously registered with a compatibility break, then depending on how the "after compatibility" was set, it may be necessary to register a compatibility break with the new fingerprint.

The tests for this gem are pretty repetitive between the canonical form and the fingerprint. I kept the separation for now, but it may make sense to consolidate them in a later change.