### PR TITLE
Ruby 3.0 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: salsify/ruby_ci:2.5.8
+      - image: salsify/ruby_ci:2.6.6
     working_directory: ~/avro-resolution_canonical_form
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v2-gems-ruby-2.5.8-{{ checksum "avro-resolution_canonical_form.gemspec" }}-{{ checksum "Gemfile" }}
-            - v2-gems-ruby-2.5.8-
+            - v2-gems-ruby-2.6.6-{{ checksum "avro-resolution_canonical_form.gemspec" }}-{{ checksum "Gemfile" }}
+            - v2-gems-ruby-2.6.6-
       - run:
           name: Install Gems
           command: |
@@ -18,7 +18,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v2-gems-ruby-2.5.8-{{ checksum "avro-resolution_canonical_form.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v2-gems-ruby-2.6.6-{{ checksum "avro-resolution_canonical_form.gemspec" }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
@@ -66,6 +66,6 @@ workflows:
           matrix:
             parameters:
               ruby-version:
-                - "2.5.8"
                 - "2.6.6"
                 - "2.7.2"
+                - "3.0.0"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,12 @@
 inherit_gem:
   salsify_rubocop: conf/rubocop.yml
 
-Style/FileName:
+AllCops:
+  TargetRubyVersion: 2.6
+
+Naming/FileName:
   Exclude:
     - 'lib/avro-resolution_canonical_form.rb'
 
 RSpec/FilePath:
   Enabled: false
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.4.0 (Unreleased)
 - Drop dependency on `avro-patches`.
+- Add support for Ruby 3.0.
+- Drop support for Ruby < 2.6.
+- Use frozen string literals.
 
 ## v0.3.0
 - Require Avro v1.10.

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # override the :github shortcut to be secure by using HTTPS

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 
 require 'rspec/core/rake_task'

--- a/avro-resolution_canonical_form.gemspec
+++ b/avro-resolution_canonical_form.gemspec
@@ -1,6 +1,6 @@
-# coding: utf-8
+# frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'avro-resolution_canonical_form/version'
 
@@ -28,12 +28,14 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.6'
+
   spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'overcommit'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.8'
   spec.add_development_dependency 'rspec_junit_formatter'
-  spec.add_development_dependency 'salsify_rubocop', '~> 0.46.0'
-  spec.add_development_dependency 'overcommit'
+  spec.add_development_dependency 'salsify_rubocop', '~> 1.0.1'
   spec.add_development_dependency 'simplecov'
 
   spec.add_runtime_dependency 'avro', '~> 1.10.0'

--- a/lib/avro-resolution_canonical_form.rb
+++ b/lib/avro-resolution_canonical_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avro'
 require 'avro-resolution_canonical_form/version'
 require 'avro/resolution_canonical_form'

--- a/lib/avro-resolution_canonical_form/version.rb
+++ b/lib/avro-resolution_canonical_form/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AvroResolutionCanonicalForm
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.0'
 end

--- a/lib/avro/resolution_canonical_form.rb
+++ b/lib/avro/resolution_canonical_form.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 module Avro
   class ResolutionCanonicalForm < Avro::SchemaNormalization
-    DECIMAL_LOGICAL_TYPE = 'decimal'.freeze
+    DECIMAL_LOGICAL_TYPE = 'decimal'
 
     def self.to_resolution_form(schema)
       new.to_resolution_form(schema)
@@ -23,9 +25,7 @@ module Avro
     def normalize_field(field)
       extensions = {}
       extensions[:default] = field.default if field.default?
-      if field.aliases && !field.aliases.empty?
-        extensions[:aliases] = field.aliases.sort
-      end
+      extensions[:aliases] = field.aliases.sort if field.aliases && !field.aliases.empty?
 
       super.merge(extensions)
     end
@@ -43,9 +43,9 @@ module Avro
 
     def normalize_named_type(schema, attributes = {})
       extensions = {}
-      if schema.respond_to?(:default)
+      if schema.respond_to?(:default) && !schema.default.nil?
         # For enum defaults
-        extensions[:default] = schema.default unless schema.default.nil?
+        extensions[:default] = schema.default
       end
 
       aliases = schema.fullname_aliases

--- a/lib/avro/resolution_fingerprint.rb
+++ b/lib/avro/resolution_fingerprint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avro
   class Schema
     # Returns the SHA-256 fingerprint of the Resolution Canonical Form for the

--- a/spec/avro/resolution_canonical_form_spec.rb
+++ b/spec/avro/resolution_canonical_form_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 describe Avro::ResolutionCanonicalForm do
   let(:resolution_form) { described_class.to_resolution_form(schema) }
 
-  describe "self.to_resolution_form" do
+  describe ".to_resolution_form" do
     context "primitive types" do
-      %w(null boolean string bytes int long float double).each do |type|
+      ['null', 'boolean', 'string', 'bytes', 'int', 'long', 'float', 'double'].each do |type|
         it "returns the resolution canonical form for '#{type}'" do
           schema = Avro::Schema.parse(<<-JSON)
             { "type": "#{type}" }

--- a/spec/avro/resolution_fingerprint_spec.rb
+++ b/spec/avro/resolution_fingerprint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Avro::Schema, "#sha256_resolution_fingerprint" do
   describe "#sha256_resolution_fingerprint" do
     let(:fingerprint) { schema.sha256_resolution_fingerprint }

--- a/spec/avro_resolution_canonical_form_spec.rb
+++ b/spec/avro_resolution_canonical_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe AvroResolutionCanonicalForm, 'VERSION' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'simplecov'
 SimpleCov.start
 


### PR DESCRIPTION
This PR adds support for Ruby 3.0 and drops support for Ruby < 2.6. The most interesting part of the change is a required Rubocop upgrade.