### PR TITLE
Require Avro v1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: salsify/ruby_ci:2.6.6
+      - image: salsify/ruby_ci:2.6.8
     working_directory: ~/avro-resolution_canonical_form
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v2-gems-ruby-2.6.6-{{ checksum "avro-resolution_canonical_form.gemspec" }}-{{ checksum "Gemfile" }}
-            - v2-gems-ruby-2.6.6-
+            - v2-gems-ruby-2.6.8-{{ checksum "avro-resolution_canonical_form.gemspec" }}-{{ checksum "Gemfile" }}
+            - v2-gems-ruby-2.6.8-
       - run:
           name: Install Gems
           command: |
@@ -18,7 +18,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v2-gems-ruby-2.6.6-{{ checksum "avro-resolution_canonical_form.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v2-gems-ruby-2.6.8-{{ checksum "avro-resolution_canonical_form.gemspec" }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
@@ -66,6 +66,6 @@ workflows:
           matrix:
             parameters:
               ruby-version:
-                - "2.6.6"
-                - "2.7.2"
-                - "3.0.0"
+                - "2.6.8"
+                - "2.7.4"
+                - "3.0.2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avro-resolution_canonical_form
 
+## v0.5.0
+- Require Avro v1.11.
+
 ## v0.4.0
 - Drop dependency on `avro-patches`.
 - Add support for Ruby 3.0.

--- a/avro-resolution_canonical_form.gemspec
+++ b/avro-resolution_canonical_form.gemspec
@@ -38,18 +38,16 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'salsify_rubocop', '~> 1.0.1'
   spec.add_development_dependency 'simplecov'
 
-  spec.add_runtime_dependency 'avro', '~> 1.10.0'
+  spec.add_runtime_dependency 'avro', '~> 1.11.0'
 
   spec.post_install_message = %(
-avro-resolution_canonical_form now requires Avro v1.10.
+avro-resolution_canonical_form now requires Avro v1.11.
 
-New features in Avro Ruby v1.10 are now included in the canonical form:
-  - aliases
-  - enum defaults
-  - decimal logical types
+Avro Ruby v1.11 adds support for decimal logical type attributes on fixed types and these attributes are
+included in the resolution canonical form.
 
-Schemas that use any of these features will get a different fingerprint with
+Schemas that use these attributes will get a different fingerprint with
 this version. For projects that only use Ruby, use of these features is unlikely
-as they were previously unsupported.
+as they were previously unsupported, and encoding/decoding fixed decimals is not yet supported.
 )
 end

--- a/spec/avro/resolution_canonical_form_spec.rb
+++ b/spec/avro/resolution_canonical_form_spec.rb
@@ -241,9 +241,8 @@ describe Avro::ResolutionCanonicalForm do
         JSON
       end
       let(:expected_type) do
-        # This is expected to change to the decimal logical type is fully supported for fixed in Avro Ruby
         <<-JSON.strip
-          {"name":"logical.my_decimal","type":"fixed","size":10,"aliases":["logical.precise","number.logical"],"logicalType":"decimal"}
+          {"name":"logical.my_decimal","type":"fixed","size":10,"aliases":["logical.precise","number.logical"],"logicalType":"decimal","precision":8,"scale":2}
         JSON
       end
 

--- a/spec/avro/resolution_fingerprint_spec.rb
+++ b/spec/avro/resolution_fingerprint_spec.rb
@@ -220,8 +220,7 @@ describe Avro::Schema, "#sha256_resolution_fingerprint" do
       end
 
       let(:expected) do
-        # This is expected to change to the decimal logical type is fully supported for fixed in Avro Ruby
-        109010719941921900671474271265982157895832083260603382288605526885391235302023
+        23517667177914137933250943145465353860935200939996710206937621647303295060610
       end
 
       it_behaves_like "a fingerprint based on the resolution canonical form"


### PR DESCRIPTION
Similar to the last major Avro release, there are changes in Avro v1.11.0 for Ruby that will change the signature for some schemas. In practice, this is unlikely to have much impact.