### PR TITLE
Add Ruby 3.2 & Drop Ruby 2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: salsify/ruby_ci:2.6.8
+      - image: salsify/ruby_ci:2.7.7
     working_directory: ~/avro-resolution_canonical_form
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v2-gems-ruby-2.6.8-{{ checksum "avro-resolution_canonical_form.gemspec" }}-{{ checksum "Gemfile" }}
-            - v2-gems-ruby-2.6.8-
+            - v2-gems-ruby-2.7.7-{{ checksum "avro-resolution_canonical_form.gemspec" }}-{{ checksum "Gemfile" }}
+            - v2-gems-ruby-2.7.7-
       - run:
           name: Install Gems
           command: |
@@ -18,7 +18,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v2-gems-ruby-2.6.8-{{ checksum "avro-resolution_canonical_form.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v2-gems-ruby-2.7.7-{{ checksum "avro-resolution_canonical_form.gemspec" }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
@@ -66,6 +66,7 @@ workflows:
           matrix:
             parameters:
               ruby-version:
-                - "2.6.8"
-                - "2.7.4"
-                - "3.0.2"
+                - "2.7.7"
+                - "3.0.5"
+                - "3.1.3"
+                - "3.2.0"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   salsify_rubocop: conf/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 Naming/FileName:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # avro-resolution_canonical_form
 
+## v0.6.0
+- Add support for Ruby 3.2.
+- Drop support for Ruby 2.6.
+
 ## v0.5.0
 - Require Avro v1.11.
 

--- a/avro-resolution_canonical_form.gemspec
+++ b/avro-resolution_canonical_form.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'overcommit'

--- a/lib/avro-resolution_canonical_form/version.rb
+++ b/lib/avro-resolution_canonical_form/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AvroResolutionCanonicalForm
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
This adds support for Ruby 3.2 and drops support for Ruby 2.6. No changes were required to get tests passing with Ruby 3.2.